### PR TITLE
Fix Error [ERR_MODULE_NOT_FOUND]: Cannot find package 'pkg-versions' imported from /.../manakit/dist/check-version.js

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "manakit",
-	"version": "0.6.0",
+	"version": "0.6.1",
 	"scripts": {
 		"dev": "vite dev",
 		"build": "vite build && npm run package",
@@ -46,7 +46,6 @@
 		"eslint": "^8.56.0",
 		"eslint-config-prettier": "^9.1.0",
 		"eslint-plugin-svelte": "^2.35.1",
-		"pkg-versions": "^4.0.0",
 		"prettier": "^3.1.1",
 		"prettier-plugin-svelte": "^3.1.2",
 		"publint": "^0.1.9",
@@ -56,6 +55,9 @@
 		"tslib": "^2.4.1",
 		"typescript": "^5.0.0",
 		"vite": "^5.0.11"
+	},
+	"dependencies": {
+		"pkg-versions": "^4.0.0"
 	},
 	"svelte": "./dist/index.js",
 	"types": "./dist/index.d.ts",


### PR DESCRIPTION
move "pkg-versions" on `dependencies`