### PR TITLE
Add colors class theme default and custom theme to manakit

### DIFF
--- a/src/assets/scss/libs/colors.scss
+++ b/src/assets/scss/libs/colors.scss
@@ -5,42 +5,104 @@
 				$valuesMerged: map.merge($theme-light, $colors);
 				@if $theme-mode == 'light' {
 					@each $name, $color in $valuesMerged {
+						@if str-index($name, 'on-') == null {
+							.#{$name} {
+								@each $moduleClass in $modules-bg-text-keys {
+									&:not(.#{$moduleClass}) {
+										--background-color: var(--#{$name});
+										--color: var(--on-#{$name});
+									}
+								}
+							}
+
+							.#{$name} {
+								@each $moduleClass in $modules-bg-text-keys {
+									&.#{$moduleClass} {
+										--color: var(--#{$name});
+									}
+								}
+							}
+						}
 						.bg\:#{$name} {
-							--background-color: var(--#{$name}) !important;
+							--background-color: var(--#{$name});
 							background-color: var(--#{$name});
 						}
 						.text\:#{$name} {
-							--color: var(--#{$name}) !important;
+							--color: var(--#{$name});
 							color: var(--#{$name});
 						}
 						.border\:#{$name} {
-							--border-color: var(--#{$name}) !important;
+							--border-color: var(--#{$name});
 							border-color: var(--#{$name});
 						}
 					}
 				} @else {
 					@media (prefers-color-scheme: light) {
 						@each $name, $color in $valuesMerged {
+							@if str-index($name, 'on-') == null {
+								.#{$name} {
+									@each $moduleClass in $modules-bg-text-keys {
+										&:not(.#{$moduleClass}) {
+											--background-color: var(--#{$name});
+											--color: var(--on-#{$name});
+										}
+									}
+								}
+
+								.#{$name} {
+									@each $moduleClass in $modules-bg-text-keys {
+										&.#{$moduleClass} {
+											--color: var(--#{$name});
+										}
+									}
+								}
+							}
+
 							.bg\:#{$name} {
+								--background-color: var(--#{$name});
 								background-color: var(--#{$name});
 							}
 							.text\:#{$name} {
+								--color: var(--#{$name});
 								color: var(--#{$name});
 							}
 							.border\:#{$name} {
+								--border-color: var(--#{$name});
 								border-color: var(--#{$name});
 							}
 						}
 					}
 					.light {
 						@each $name, $color in $valuesMerged {
+							@if str-index($name, 'on-') == null {
+								.#{$name} {
+									@each $moduleClass in $modules-bg-text-keys {
+										&:not(.#{$moduleClass}) {
+											--background-color: var(--#{$name});
+											--color: var(--on-#{$name});
+										}
+									}
+								}
+
+								.#{$name} {
+									@each $moduleClass in $modules-bg-text-keys {
+										&.#{$moduleClass} {
+											--color: var(--#{$name});
+										}
+									}
+								}
+							}
+
 							.bg\:#{$name} {
+								--background-color: var(--#{$name});
 								background-color: var(--#{$name});
 							}
 							.text\:#{$name} {
+								--color: var(--#{$name});
 								color: var(--#{$name});
 							}
 							.border\:#{$name} {
+								--border-color: var(--#{$name});
 								border-color: var(--#{$name});
 							}
 						}
@@ -51,39 +113,105 @@
 				$valuesMerged: map.merge($theme-dark, $colors);
 				@if $theme-mode == 'dark' {
 					@each $name, $color in $valuesMerged {
+						@if str-index($name, 'on-') == null {
+							.#{$name} {
+								@each $moduleClass in $modules-bg-text-keys {
+									&:not(.#{$moduleClass}) {
+										--background-color: var(--#{$name});
+										--color: var(--on-#{$name});
+									}
+								}
+							}
+
+							.#{$name} {
+								@each $moduleClass in $modules-bg-text-keys {
+									&.#{$moduleClass} {
+										--color: var(--#{$name});
+									}
+								}
+							}
+						}
+
 						.bg\:#{$name} {
+							--background-color: var(--#{$name});
 							background-color: var(--#{$name});
 						}
 						.text\:#{$name} {
+							--color: var(--#{$name});
 							color: var(--#{$name});
 						}
 						.border\:#{$name} {
+							--border-color: var(--#{$name});
 							border-color: var(--#{$name});
 						}
 					}
 				} @else {
 					@media (prefers-color-scheme: dark) {
 						@each $name, $color in $valuesMerged {
+							@if str-index($name, 'on-') == null {
+								.#{$name} {
+									@each $moduleClass in $modules-bg-text-keys {
+										&:not(.#{$moduleClass}) {
+											--background-color: var(--#{$name});
+											--color: var(--on-#{$name});
+										}
+									}
+								}
+
+								.#{$name} {
+									@each $moduleClass in $modules-bg-text-keys {
+										&.#{$moduleClass} {
+											--color: var(--#{$name});
+										}
+									}
+								}
+							}
+
 							.bg\:#{$name} {
+								--background-color: var(--#{$name});
 								background-color: var(--#{$name});
 							}
 							.text\:#{$name} {
+								--color: var(--#{$name});
 								color: var(--#{$name});
 							}
 							.border\:#{$name} {
+								--border-color: var(--#{$name});
 								border-color: var(--#{$name});
 							}
 						}
 					}
 					.dark {
 						@each $name, $color in $valuesMerged {
+							@if str-index($name, 'on-') == null {
+								.#{$name} {
+									@each $moduleClass in $modules-bg-text-keys {
+										&:not(.#{$moduleClass}) {
+											--background-color: var(--#{$name});
+											--color: var(--on-#{$name});
+										}
+									}
+								}
+
+								.#{$name} {
+									@each $moduleClass in $modules-bg-text-keys {
+										&.#{$moduleClass} {
+											--color: var(--#{$name});
+										}
+									}
+								}
+							}
+
 							.bg\:#{$name} {
+								--background-color: var(--#{$name});
 								background-color: var(--#{$name});
 							}
 							.text\:#{$name} {
+								--color: var(--#{$name});
 								color: var(--#{$name});
 							}
 							.border\:#{$name} {
+								--border-color: var(--#{$name});
 								border-color: var(--#{$name});
 							}
 						}
@@ -95,13 +223,35 @@
 				@if $theme-mode == 'light' {
 					.#{$theme} {
 						@each $name, $color in $valuesMerged {
+							@if str-index($name, 'on-') == null {
+								.#{$name} {
+									@each $moduleClass in $modules-bg-text-keys {
+										&:not(.#{$moduleClass}) {
+											--background-color: var(--#{$name});
+											--color: var(--on-#{$name});
+										}
+									}
+								}
+
+								.#{$name} {
+									@each $moduleClass in $modules-bg-text-keys {
+										&.#{$moduleClass} {
+											--color: var(--#{$name});
+										}
+									}
+								}
+							}
+
 							.bg\:#{$name} {
+								--background-color: var(--#{$name});
 								background-color: var(--#{$name});
 							}
 							.text\:#{$name} {
+								--color: var(--#{$name});
 								color: var(--#{$name});
 							}
 							.border\:#{$name} {
+								--border-color: var(--#{$name});
 								border-color: var(--#{$name});
 							}
 						}
@@ -109,26 +259,70 @@
 				} @else {
 					@media (prefers-color-scheme: light) {
 						@each $name, $color in $valuesMerged {
+							@if str-index($name, 'on-') == null {
+								.#{$name} {
+									@each $moduleClass in $modules-bg-text-keys {
+										&:not(.#{$moduleClass}) {
+											--background-color: var(--#{$name});
+											--color: var(--on-#{$name});
+										}
+									}
+								}
+
+								.#{$name} {
+									@each $moduleClass in $modules-bg-text-keys {
+										&.#{$moduleClass} {
+											--color: var(--#{$name});
+										}
+									}
+								}
+							}
+
 							.bg\:#{$name} {
+								--background-color: var(--#{$name});
 								background-color: var(--#{$name});
 							}
 							.text\:#{$name} {
+								--color: var(--#{$name});
 								color: var(--#{$name});
 							}
 							.border\:#{$name} {
+								--border-color: var(--#{$name});
 								border-color: var(--#{$name});
 							}
 						}
 					}
 					.#{$theme}.light {
 						@each $name, $color in $valuesMerged {
+							@if str-index($name, 'on-') == null {
+								.#{$name} {
+									@each $moduleClass in $modules-bg-text-keys {
+										&:not(.#{$moduleClass}) {
+											--background-color: var(--#{$name});
+											--color: var(--on-#{$name});
+										}
+									}
+								}
+
+								.#{$name} {
+									@each $moduleClass in $modules-bg-text-keys {
+										&.#{$moduleClass} {
+											--color: var(--#{$name});
+										}
+									}
+								}
+							}
+
 							.bg\:#{$name} {
+								--background-color: var(--#{$name});
 								background-color: var(--#{$name});
 							}
 							.text\:#{$name} {
+								--color: var(--#{$name});
 								color: var(--#{$name});
 							}
 							.border\:#{$name} {
+								--border-color: var(--#{$name});
 								border-color: var(--#{$name});
 							}
 						}
@@ -139,13 +333,35 @@
 				@if $theme-mode == 'dark' {
 					.#{$theme} {
 						@each $name, $color in $valuesMerged {
+							@if str-index($name, 'on-') == null {
+								.#{$name} {
+									@each $moduleClass in $modules-bg-text-keys {
+										&:not(.#{$moduleClass}) {
+											--background-color: var(--#{$name});
+											--color: var(--on-#{$name});
+										}
+									}
+								}
+
+								.#{$name} {
+									@each $moduleClass in $modules-bg-text-keys {
+										&.#{$moduleClass} {
+											--color: var(--#{$name});
+										}
+									}
+								}
+							}
+
 							.bg\:#{$name} {
+								--background-color: var(--#{$name});
 								background-color: var(--#{$name});
 							}
 							.text\:#{$name} {
+								--color: var(--#{$name});
 								color: var(--#{$name});
 							}
 							.border\:#{$name} {
+								--border-color: var(--#{$name});
 								border-color: var(--#{$name});
 							}
 						}
@@ -154,13 +370,35 @@
 					@media (prefers-color-scheme: dark) {
 						.#{$theme} {
 							@each $name, $color in $valuesMerged {
+								@if str-index($name, 'on-') == null {
+									.#{$name} {
+										@each $moduleClass in $modules-bg-text-keys {
+											&:not(.#{$moduleClass}) {
+												--background-color: var(--#{$name});
+												--color: var(--on-#{$name});
+											}
+										}
+									}
+
+									.#{$name} {
+										@each $moduleClass in $modules-bg-text-keys {
+											&.#{$moduleClass} {
+												--color: var(--#{$name});
+											}
+										}
+									}
+								}
+
 								.bg\:#{$name} {
+									--background-color: var(--#{$name});
 									background-color: var(--#{$name});
 								}
 								.text\:#{$name} {
+									--color: var(--#{$name});
 									color: var(--#{$name});
 								}
 								.border\:#{$name} {
+									--border-color: var(--#{$name});
 									border-color: var(--#{$name});
 								}
 							}
@@ -168,13 +406,35 @@
 					}
 					.#{$theme}.dark {
 						@each $name, $color in $valuesMerged {
+							@if str-index($name, 'on-') == null {
+								.#{$name} {
+									@each $moduleClass in $modules-bg-text-keys {
+										&:not(.#{$moduleClass}) {
+											--background-color: var(--#{$name});
+											--color: var(--on-#{$name});
+										}
+									}
+								}
+
+								.#{$name} {
+									@each $moduleClass in $modules-bg-text-keys {
+										&.#{$moduleClass} {
+											--color: var(--#{$name});
+										}
+									}
+								}
+							}
+
 							.bg\:#{$name} {
+								--background-color: var(--#{$name});
 								background-color: var(--#{$name});
 							}
 							.text\:#{$name} {
+								--color: var(--#{$name});
 								color: var(--#{$name});
 							}
 							.border\:#{$name} {
+								--border-color: var(--#{$name});
 								border-color: var(--#{$name});
 							}
 						}

--- a/src/assets/scss/libs/colors.scss
+++ b/src/assets/scss/libs/colors.scss
@@ -1,0 +1,186 @@
+@each $theme, $values in $themes-custom {
+	@each $nuance, $colors in $values {
+		@if ($theme == 'default') {
+			@if $nuance == 'light' {
+				$valuesMerged: map.merge($theme-light, $colors);
+				@if $theme-mode == 'light' {
+					@each $name, $color in $valuesMerged {
+						.bg\:#{$name} {
+							--background-color: var(--#{$name}) !important;
+							background-color: var(--#{$name});
+						}
+						.text\:#{$name} {
+							--color: var(--#{$name}) !important;
+							color: var(--#{$name});
+						}
+						.border\:#{$name} {
+							--border-color: var(--#{$name}) !important;
+							border-color: var(--#{$name});
+						}
+					}
+				} @else {
+					@media (prefers-color-scheme: light) {
+						@each $name, $color in $valuesMerged {
+							.bg\:#{$name} {
+								background-color: var(--#{$name});
+							}
+							.text\:#{$name} {
+								color: var(--#{$name});
+							}
+							.border\:#{$name} {
+								border-color: var(--#{$name});
+							}
+						}
+					}
+					.light {
+						@each $name, $color in $valuesMerged {
+							.bg\:#{$name} {
+								background-color: var(--#{$name});
+							}
+							.text\:#{$name} {
+								color: var(--#{$name});
+							}
+							.border\:#{$name} {
+								border-color: var(--#{$name});
+							}
+						}
+					}
+				}
+			}
+			@if $nuance == 'dark' {
+				$valuesMerged: map.merge($theme-dark, $colors);
+				@if $theme-mode == 'dark' {
+					@each $name, $color in $valuesMerged {
+						.bg\:#{$name} {
+							background-color: var(--#{$name});
+						}
+						.text\:#{$name} {
+							color: var(--#{$name});
+						}
+						.border\:#{$name} {
+							border-color: var(--#{$name});
+						}
+					}
+				} @else {
+					@media (prefers-color-scheme: dark) {
+						@each $name, $color in $valuesMerged {
+							.bg\:#{$name} {
+								background-color: var(--#{$name});
+							}
+							.text\:#{$name} {
+								color: var(--#{$name});
+							}
+							.border\:#{$name} {
+								border-color: var(--#{$name});
+							}
+						}
+					}
+					.dark {
+						@each $name, $color in $valuesMerged {
+							.bg\:#{$name} {
+								background-color: var(--#{$name});
+							}
+							.text\:#{$name} {
+								color: var(--#{$name});
+							}
+							.border\:#{$name} {
+								border-color: var(--#{$name});
+							}
+						}
+					}
+				}
+			}
+		} @else {
+			@if $nuance == 'light' {
+				@if $theme-mode == 'light' {
+					.#{$theme} {
+						@each $name, $color in $valuesMerged {
+							.bg\:#{$name} {
+								background-color: var(--#{$name});
+							}
+							.text\:#{$name} {
+								color: var(--#{$name});
+							}
+							.border\:#{$name} {
+								border-color: var(--#{$name});
+							}
+						}
+					}
+				} @else {
+					@media (prefers-color-scheme: light) {
+						@each $name, $color in $valuesMerged {
+							.bg\:#{$name} {
+								background-color: var(--#{$name});
+							}
+							.text\:#{$name} {
+								color: var(--#{$name});
+							}
+							.border\:#{$name} {
+								border-color: var(--#{$name});
+							}
+						}
+					}
+					.#{$theme}.light {
+						@each $name, $color in $valuesMerged {
+							.bg\:#{$name} {
+								background-color: var(--#{$name});
+							}
+							.text\:#{$name} {
+								color: var(--#{$name});
+							}
+							.border\:#{$name} {
+								border-color: var(--#{$name});
+							}
+						}
+					}
+				}
+			}
+			@if $nuance == 'dark' {
+				@if $theme-mode == 'dark' {
+					.#{$theme} {
+						@each $name, $color in $valuesMerged {
+							.bg\:#{$name} {
+								background-color: var(--#{$name});
+							}
+							.text\:#{$name} {
+								color: var(--#{$name});
+							}
+							.border\:#{$name} {
+								border-color: var(--#{$name});
+							}
+						}
+					}
+				} @else {
+					@media (prefers-color-scheme: dark) {
+						.#{$theme} {
+							@each $name, $color in $valuesMerged {
+								.bg\:#{$name} {
+									background-color: var(--#{$name});
+								}
+								.text\:#{$name} {
+									color: var(--#{$name});
+								}
+								.border\:#{$name} {
+									border-color: var(--#{$name});
+								}
+							}
+						}
+					}
+					.#{$theme}.dark {
+						@each $name, $color in $valuesMerged {
+							.bg\:#{$name} {
+								background-color: var(--#{$name});
+							}
+							.text\:#{$name} {
+								color: var(--#{$name});
+							}
+							.border\:#{$name} {
+								border-color: var(--#{$name});
+							}
+						}
+					}
+				}
+			}
+		}
+	}
+}

--- a/src/assets/scss/variables.scss
+++ b/src/assets/scss/variables.scss
@@ -1,5 +1,15 @@
 @use 'sass:map';
 
+// modules colors theme global
+$modules-bg-text-keys: (
+	'btn-outline',
+	'btn-text',
+	'btn-link',
+	'card-outline',
+	'card-text',
+	'mk-divider'
+);
+
 // fonts
 $fonts-initial: (
 	title: "'Ubuntu', sans-serif",

--- a/src/importer.ts
+++ b/src/importer.ts
@@ -41,9 +41,9 @@ export async function makeManakitImporterConfig() {
 	}
 
 	css += convertJStoSCSS(config);
-	contentSCSS.map((pathFile) => (css += fs.readFileSync(pathFile, 'utf-8')));
-	modulesSCSS.map((pathFile) => (css += fs.readFileSync(pathFile, 'utf-8')));
 
+	modulesSCSS.map((pathFile) => (css += fs.readFileSync(pathFile, 'utf-8')));
+	contentSCSS.map((pathFile) => (css += fs.readFileSync(pathFile, 'utf-8')));
 	fsPromises.writeFile(
 		path.resolve(`node_modules/manakit/dist`, 'style.css'),
 		sass.compileString(css)?.css

--- a/src/modules/btn/btn.scss
+++ b/src/modules/btn/btn.scss
@@ -1,6 +1,6 @@
 .mk-btn {
-	--btn-color: var(--on-surface);
-	--btn-background: var(--surface);
+	--color: var(--on-surface);
+	--background-color: var(--surface);
 
 	display: inline-flex;
 	height: 3rem;
@@ -27,8 +27,8 @@
 	transition-duration: 0.2s;
 	transition-timing-function: cubic-bezier(0, 0, 0.2, 1);
 	animation: button-effect 0.25s ease-out;
-	color: var(--btn-color);
-	background-color: var(--btn-background);
+	color: var(--color);
+	background-color: var(--background-color);
 
 	svg {
 		width: 1.5rem;
@@ -42,7 +42,7 @@
 	}
 
 	&:hover {
-		background: color-mix(in oklab, var(--btn-background) 90%, black);
+		background: color-mix(in oklab, var(--background-color) 90%, black);
 	}
 
 	&.btn-square {
@@ -60,17 +60,17 @@
 	}
 	&.btn-outline {
 		background-color: transparent;
-		border-color: var(--btn-color);
+		border-color: var(--color);
 
 		&:hover {
-			background-color: color-mix(in oklab, var(--btn-color) 20%, transparent);
+			background-color: color-mix(in oklab, var(--color) 20%, transparent);
 		}
 	}
 	&.btn-text {
 		background-color: transparent;
 
 		&:hover {
-			background-color: color-mix(in oklab, var(--btn-color) 20%, transparent);
+			background-color: color-mix(in oklab, var(--color) 20%, transparent);
 		}
 	}
 	&.btn-link {
@@ -131,49 +131,49 @@
 	}
 	&.mk-btn:is(input[type='checkbox']:checked),
 	&.mk-btn:is(input[type='radio']:checked) {
-		--btn-color: var(--on-primary);
-		--btn-background: var(--primary);
+		--color: var(--on-primary);
+		--background-color: var(--primary);
 	}
 
 	// colors
 	&.btn-info {
-		--btn-color: var(--on-info);
-		--btn-background: var(--info);
+		--color: var(--on-info);
+		--background-color: var(--info);
 
 		&.btn-outline,
 		&.btn-text,
 		&.btn-info {
-			--btn-color: var(--info);
+			--color: var(--info);
 		}
 	}
 	&.btn-success {
-		--btn-color: var(--on-success);
-		--btn-background: var(--success);
+		--color: var(--on-success);
+		--background-color: var(--success);
 
 		&.btn-outline,
 		&.btn-text,
 		&.btn-info {
-			--btn-color: var(--success);
+			--color: var(--success);
 		}
 	}
 	&.btn-warning {
-		--btn-color: var(--on-warning);
-		--btn-background: var(--warning);
+		--color: var(--on-warning);
+		--background-color: var(--warning);
 
 		&.btn-outline,
 		&.btn-text,
 		&.btn-info {
-			--btn-color: var(--warning);
+			--color: var(--warning);
 		}
 	}
 	&.btn-error {
-		--btn-color: var(--on-error);
-		--btn-background: var(--error);
+		--color: var(--on-error);
+		--background-color: var(--error);
 
 		&.btn-outline,
 		&.btn-text,
 		&.btn-info {
-			--btn-color: var(--error);
+			--color: var(--error);
 		}
 	}
 

--- a/src/modules/btn/btn.scss
+++ b/src/modules/btn/btn.scss
@@ -41,8 +41,8 @@
 		transform: scale(0.97);
 	}
 
-	&:hover {
-		background: color-mix(in oklab, var(--background-color) 90%, black);
+	&:hover:not(.btn-outline):not(.btn-text):not(.btn-link) {
+		background-color: color-mix(in oklab, var(--background-color) 90%, black);
 	}
 
 	&.btn-square {
@@ -90,11 +90,11 @@
 	&.btn[disabled] {
 		pointer-events: none;
 		user-select: none;
-		color: color-mix(in oklab, var(--scrim) 40%, transparent);
-		background-color: color-mix(in oklab, var(--surface) 70%, transparent);
+		color: color-mix(in oklab, var(--color) 40%, transparent) !important;
+		background-color: color-mix(in oklab, var(--background-color) 70%, transparent) !important;
 
 		&.btn-outline {
-			border-color: color-mix(in oklab, var(--scrim) 40%, transparent);
+			border-color: color-mix(in oklab, var(--color) 40%, transparent) !important;
 		}
 
 		&.btn-outline,
@@ -142,7 +142,7 @@
 
 		&.btn-outline,
 		&.btn-text,
-		&.btn-info {
+		&.btn-link {
 			--color: var(--info);
 		}
 	}
@@ -152,7 +152,7 @@
 
 		&.btn-outline,
 		&.btn-text,
-		&.btn-info {
+		&.btn-link {
 			--color: var(--success);
 		}
 	}
@@ -162,7 +162,7 @@
 
 		&.btn-outline,
 		&.btn-text,
-		&.btn-info {
+		&.btn-link {
 			--color: var(--warning);
 		}
 	}
@@ -172,7 +172,7 @@
 
 		&.btn-outline,
 		&.btn-text,
-		&.btn-info {
+		&.btn-link {
 			--color: var(--error);
 		}
 	}

--- a/src/modules/card/card.scss
+++ b/src/modules/card/card.scss
@@ -4,7 +4,7 @@ a.mk-card {
 
 .mk-card {
 	--color: var(--on-surface);
-	--background-color: var(--surface);
+	--background-color-color: var(--surface);
 	--overlay: var(--scrim);
 	--border-radius: 1rem;
 
@@ -17,19 +17,19 @@ a.mk-card {
 	border-style: solid;
 	text-align: start;
 	color: var(--color);
-	background-color: var(--background);
+	background-color: var(--background-color);
 
 	&:hover:not(div) {
-		background-color: color-mix(in oklab, var(--background) 90%, black);
+		background-color: color-mix(in oklab, var(--background-color) 90%, black);
 	}
 
 	&:focus:not(div) {
-		background-color: color-mix(in oklab, var(--background) 95%, black);
+		background-color: color-mix(in oklab, var(--background-color) 95%, black);
 	}
 
 	&:active:not(div),
 	&.card-active {
-		background-color: color-mix(in oklab, var(--background) 95%, black);
+		background-color: color-mix(in oklab, var(--background-color) 95%, black);
 	}
 
 	&:not(div) {

--- a/src/modules/card/card.scss
+++ b/src/modules/card/card.scss
@@ -3,32 +3,33 @@ a.mk-card {
 }
 
 .mk-card {
-	--card-background: var(--surface);
-	--card-color: var(--on-surface);
-	--card-overlay: var(--scrim);
-	--card-border-radius: 1rem;
+	--color: var(--on-surface);
+	--background-color: var(--surface);
+	--overlay: var(--scrim);
+	--border-radius: 1rem;
 
 	position: relative;
 	display: flex;
 	flex-direction: column;
-	border-radius: var(--card-border-radius);
+	border-radius: var(--border-radius);
 	border-color: transparent;
 	border-width: 1px;
 	border-style: solid;
-	color: var(--card-color);
-	background-color: var(--card-background);
+	text-align: start;
+	color: var(--color);
+	background-color: var(--background);
 
 	&:hover:not(div) {
-		background-color: color-mix(in oklab, var(--card-background) 90%, black);
+		background-color: color-mix(in oklab, var(--background) 90%, black);
 	}
 
 	&:focus:not(div) {
-		background-color: color-mix(in oklab, var(--card-background) 95%, black);
+		background-color: color-mix(in oklab, var(--background) 95%, black);
 	}
 
 	&:active:not(div),
 	&.card-active {
-		background-color: color-mix(in oklab, var(--card-background) 95%, black);
+		background-color: color-mix(in oklab, var(--background) 95%, black);
 	}
 
 	&:not(div) {
@@ -36,12 +37,25 @@ a.mk-card {
 	}
 
 	&.card-outline {
-		background: transparent;
-		border-color: var(--card-color);
+		border-color: var(--color);
 	}
 
+	&.card-outline,
 	&.card-text {
-		background: transparent;
+		background-color: transparent;
+
+		&:hover:not(div) {
+			background-color: color-mix(in oklab, var(--color) 20%, transparent);
+		}
+
+		&:focus:not(div) {
+			background-color: color-mix(in oklab, var(--color) 25%, transparent);
+		}
+
+		&:active:not(div),
+		&.card-active {
+			background-color: color-mix(in oklab, var(--color) 25%, transparent);
+		}
 	}
 
 	&.card-disabled,
@@ -49,18 +63,24 @@ a.mk-card {
 	&:disabled {
 		pointer-events: none;
 		user-select: none;
-		color: color-mix(in oklab, var(--scrim) 25%, transparent);
+		color: color-mix(in oklab, var(--scrim) 25%, transparent) !important;
 
-		&::before {
-			content: '';
-			position: absolute;
-			top: 0;
-			left: 0;
-			width: 100%;
-			height: 100%;
-			background-color: color-mix(in oklab, var(--scrim) 8%, transparent);
-			z-index: 100;
-			border-radius: var(--card-border-radius);
+		&.card-outline {
+			border-color: color-mix(in oklab, var(--scrim) 25%, transparent) !important;
+		}
+
+		&:not(.card-text) {
+			&::before {
+				content: '';
+				position: absolute;
+				top: 0;
+				left: 0;
+				width: 100%;
+				height: 100%;
+				background-color: color-mix(in oklab, var(--scrim) 8%, transparent) !important;
+				z-index: 100;
+				border-radius: var(--border-radius);
+			}
 		}
 	}
 }

--- a/src/modules/card/card.scss
+++ b/src/modules/card/card.scss
@@ -4,7 +4,7 @@ a.mk-card {
 
 .mk-card {
 	--color: var(--on-surface);
-	--background-color-color: var(--surface);
+	--background-color: var(--surface);
 	--overlay: var(--scrim);
 	--border-radius: 1rem;
 

--- a/src/modules/divider/divider.scss
+++ b/src/modules/divider/divider.scss
@@ -1,5 +1,5 @@
 .mk-divider {
-	--divider-color: var(--color-on-surface);
+	--color: var(--on-surface);
 
 	display: flex;
 	flex-direction: row;
@@ -10,6 +10,15 @@
 	height: 1rem;
 	white-space: nowrap;
 
+	&:not(.divider-start)::before,
+	&:not(.divider-end)::after {
+		height: 0.125rem;
+		width: 100%;
+		flex-grow: 1;
+		content: '';
+		background-color: color-mix(in oklab, var(--color) 40%, transparent);
+	}
+
 	&:not(:empty) {
 		gap: 1rem;
 	}
@@ -19,17 +28,8 @@
 		margin: 0 auto;
 	}
 
-	&:not(.divider-start):before,
-	&:not(.divider-end):after {
-		height: 0.125rem;
-		width: 100%;
-		flex-grow: 1;
-		content: '';
-		background-color: color-mix(in oklab, var(--divider-color) 40%, transparent);
-	}
-
-	&.divider-vertical:not(.divider-start):before,
-	&.divider-vertical:not(.divider-end):after {
+	&.divider-vertical:not(.divider-start)::before,
+	&.divider-vertical:not(.divider-end)::after {
 		height: 100%;
 		width: 0.125rem;
 	}

--- a/src/modules/divider/divider.svelte
+++ b/src/modules/divider/divider.svelte
@@ -5,21 +5,16 @@
 	let _class: string | false | undefined = undefined;
 	export { _class as class };
 	export let inset: boolean = false;
+	export let start: boolean = false;
+	export let end: boolean = false;
 </script>
 
-<div class={className('mk-divider', _class)} class:divider-inset={inset} {...$$restProps}>
-	{#if $$slots.start}
-		<div class="divider-start">
-			<!-- slot: start -->
-			<slot name="start" />
-			<!-- /slot: start -->
-		</div>
-	{/if}
-	{#if $$slots.end}
-		<div class="divider-end">
-			<!-- slot: end -->
-			<slot name="end" />
-			<!-- /slot: end -->
-		</div>
-	{/if}
+<div
+	class={className('mk-divider', _class)}
+	class:divider-inset={inset}
+	class:divider-start={start}
+	class:divider-end={end}
+	{...$$restProps}
+>
+	<slot />
 </div>

--- a/src/modules/drawer/drawer.scss
+++ b/src/modules/drawer/drawer.scss
@@ -1,7 +1,7 @@
 .mk-drawer {
-	--drawer-background: var(--surface);
-	--drawer-color: var(--on-surface);
-	--drawer-overlay: var(--scrim);
+	--background-color: var(--surface);
+	--color: var(--on-surface);
+	--overlay: var(--scrim);
 
 	position: relative;
 	display: grid;
@@ -22,7 +22,7 @@
 				overflow-y: auto;
 
 				> .drawer-overlay {
-					background-color: color-mix(in oklab, var(--drawer-overlay) 30%, transparent);
+					background-color: color-mix(in oklab, var(--overlay) 30%, transparent);
 				}
 
 				> *:not(.drawer-overlay) {
@@ -59,8 +59,8 @@
 
 		> aside {
 			min-height: 100%;
-			background-color: var(--drawer-background);
-			color: var(--drawer-color);
+			background-color: var(--background-color);
+			color: var(--color);
 			overflow: auto;
 		}
 

--- a/src/modules/footer/footer.scss
+++ b/src/modules/footer/footer.scss
@@ -1,6 +1,6 @@
 .mk-footer {
-	--footer-background: var(--surface);
-	--footer-color: var(--on-surface);
+	--background-color: var(--surface);
+	--color: var(--on-surface);
 
 	display: grid;
 	width: 100%;
@@ -10,8 +10,8 @@
 	row-gap: 2.5rem;
 	font-size: 0.875rem;
 	line-height: 1.25rem;
-	background-color: var(--footer-background);
-	color: var(--footer-color);
+	background-color: var(--background-color);
+	color: var(--color);
 
 	&.footer-center {
 		place-items: center;

--- a/src/modules/modal/modal.scss
+++ b/src/modules/modal/modal.scss
@@ -1,5 +1,5 @@
 .mk-modal {
-	--modal-background: var(--scrim);
+	--backdrop: var(--scrim);
 	border: 0;
 	padding: 0;
 	width: 100%;
@@ -8,7 +8,7 @@
 	color: inherit;
 
 	&::backdrop {
-		background-color: color-mix(in oklab, var(--modal-background) 30%, transparent);
+		background-color: color-mix(in oklab, var(--backdrop) 30%, transparent);
 		animation: fade 0.2s ease-out;
 	}
 	&[open]::backdrop {

--- a/src/modules/toolbar/toolbar.scss
+++ b/src/modules/toolbar/toolbar.scss
@@ -1,13 +1,13 @@
 .mk-toolbar {
-	--toolbar-background: var(--surface);
-	--toolbar-color: var(--on-surface);
+	--background-color: var(--surface);
+	--color: var(--on-surface);
 
 	display: flex;
 	align-items: center;
 	min-height: 4rem;
 	width: 100%;
-	background-color: var(--toolbar-background);
-	color: var(--toolbar-color);
+	background-color: var(--background-color);
+	color: var(--color);
 
 	&.toolbar-bottom {
 		height: 3.5rem;

--- a/src/utils/path-scss.ts
+++ b/src/utils/path-scss.ts
@@ -17,7 +17,6 @@ export const paletteSCSS = {
 };
 
 export const contentSCSS = [
-	path.resolve(`${nodePath}`, 'main.scss'),
 	path.resolve(`${nodePathLibs}`, 'prose.scss'),
 	path.resolve(`${nodePathLibs}`, 'align-content.scss'),
 	path.resolve(`${nodePathLibs}`, 'align-item.scss'),
@@ -52,6 +51,7 @@ export const contentSCSS = [
 ];
 
 export const modulesSCSS = [
+	path.resolve(`${nodePath}`, 'main.scss'),
 	path.resolve(`${nodePathModules}/app`, 'app.scss'),
 	path.resolve(`${nodePathModules}/spacer`, 'spacer.scss'),
 	path.resolve(`${nodePathModules}/toolbar`, 'toolbar.scss'),

--- a/src/utils/path-scss.ts
+++ b/src/utils/path-scss.ts
@@ -47,7 +47,8 @@ export const contentSCSS = [
 	path.resolve(`${nodePathLibs}`, 'text-transform.scss'),
 	path.resolve(`${nodePathLibs}`, 'text-weight.scss'),
 	path.resolve(`${nodePathLibs}`, 'width.scss'),
-	path.resolve(`${nodePathLibs}`, 'wrap.scss')
+	path.resolve(`${nodePathLibs}`, 'wrap.scss'),
+	path.resolve(`${nodePathLibs}`, 'colors.scss')
 ];
 
 export const modulesSCSS = [


### PR DESCRIPTION
### What's Changed

- [new] class colors on Themes and Custom Theme.
- [update] module `Btn` for use var —color and —background-color
- [update] module `Card` for use var —color and —background-color
- [update] module `Dividier` for use var —color
- [update] module `Dividier` not use $$slots , use display class.
- [update] module `Drawer` for use var —color and —background-color
- [update] module `Modal` —var color name standard
- [update] module `Toolbar` for use var —color and —background-color
- [update] module `Footer` for use var —color and —background-color

### Patch Changes

- [bugFix] load class theme and display content not working because have conflict to order load CSS.
- [bugFix] module `Btn` for display link class and hover
- [bugFix] module `Btn` disabled not display color theme
- [update] module `Card` fix align content center if use tag button
- [bugFix] module `Divider` for display full ligne if not content
- [bugFix] module `Divider` for display start & end value in Divider
- [bugFix] module `Divider` for display full ligne if not content
- [bugFix] module `Divider` vertical class not working